### PR TITLE
Standardized locale names

### DIFF
--- a/locale/cs_CZ/locale.xml
+++ b/locale/cs_CZ/locale.xml
@@ -12,7 +12,7 @@
   *
   -->
  
-<locale name="cs_CZ" full_name="Czech">
+<locale name="cs_CZ" full_name="Čeština">
 	<message key="plugins.generic.customBlockManager.displayName">Manažer uživatelských panelů</message>
 	<message key="plugins.generic.customBlockManager.blockName">Název panelu</message>	
 	<message key="plugins.generic.customBlockManager.addBlock">Přidat panel</message>	

--- a/locale/da_DK/locale.xml
+++ b/locale/da_DK/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the da_DK (Danish) locale.
+  * Localization strings for the da_DK (Dansk) locale.
   *
   -->
  
-<locale name="da_DK" full_name="Danish">
+<locale name="da_DK" full_name="Dansk">
 	<message key="plugins.generic.customBlockManager.displayName">Custom Block Manager</message>
 	<message key="plugins.generic.customBlockManager.blockName">Elementnavn</message>	
 	<message key="plugins.generic.customBlockManager.addBlock">Tilføj element</message>	

--- a/locale/el_GR/locale.xml
+++ b/locale/el_GR/locale.xml
@@ -12,7 +12,7 @@
   *
   -->
  
-<locale name="el_GR" full_name="Greek">
+<locale name="el_GR" full_name="ελληνικά">
 	<message key="plugins.generic.customBlockManager.displayName">Διαχείριση Custom Block</message>
 	<message key="plugins.generic.customBlockManager.blockName">Όνομα Block</message>	
 	<message key="plugins.generic.customBlockManager.addBlock">Προσθήκη Block</message>	

--- a/locale/fa_IR/locale.xml
+++ b/locale/fa_IR/locale.xml
@@ -12,7 +12,7 @@
   *
   -->
  
-<locale name="fa_IR" full_name="Persian">
+<locale name="fa_IR" full_name="فارسی">
 	<message key="plugins.generic.customBlockManager.displayName">اداره بلوک آزاد</message>
 	<message key="plugins.generic.customBlockManager.blockName">نام بلوک</message>	
 	<message key="plugins.generic.customBlockManager.addBlock">افزودن بلوک</message>	

--- a/locale/id_ID/locale.xml
+++ b/locale/id_ID/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the id_ID (Indonesia) locale.
+  * Localization strings for the id_ID (Bahasa Indonesia) locale.
   *
   -->
  
-<locale name="id_ID" full_name="Indonesia">
+<locale name="id_ID" full_name="Bahasa Indonesia">
 	<message key="plugins.generic.customBlockManager.displayName">Blok Manager Umum</message> 
 	<message key="plugins.generic.customBlockManager.blockName">Nama Blok</message>	
 	<message key="plugins.generic.customBlockManager.addBlock">Tambah Blok</message>	

--- a/locale/nb_NO/locale.xml
+++ b/locale/nb_NO/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the nb_NO (Norwegian) locale.
+  * Localization strings for the nb_NO (Norsk bokmål) locale.
   *
   -->
  
-<locale name="nb_NO" full_name="Norwegian">
+<locale name="nb_NO" full_name="Norsk bokmål">
 	<message key="plugins.generic.customBlockManager.displayName">Administrasjon av tilpassede blokker</message>
 	<message key="plugins.generic.customBlockManager.blockName">Blokknavn</message>	
 	<message key="plugins.generic.customBlockManager.addBlock">Legg til blokk</message>	

--- a/locale/pt_PT/locale.xml
+++ b/locale/pt_PT/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the pt_PT (Português) locale.
+  * Localization strings for the pt_PT (Português (Portugal)) locale.
   *
   -->
  
-<locale name="pt_PT" full_name="Português">
+<locale name="pt_PT" full_name="Português (Portugal)">
 	<message key="plugins.generic.customBlockManager.displayName">Administração de Blocos Personalizados</message>
 	<message key="plugins.generic.customBlockManager.blockName">Nome do Bloco</message>	
 	<message key="plugins.generic.customBlockManager.addBlock">Adicionar Bloco</message>	

--- a/locale/ro_RO/locale.xml
+++ b/locale/ro_RO/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ro_RO (Romanian) locale.
+  * Localization strings for the ro_RO (Limba Română) locale.
   *
   -->
  
-<locale name="ro_RO" full_name="Română">
+<locale name="ro_RO" full_name="Limba Română">
 	<message key="plugins.generic.customBlockManager.displayName">Manager pentru zone particularizate după necesități</message>
 	<message key="plugins.generic.customBlockManager.blockName">Numele blocului</message>	
 	<message key="plugins.generic.customBlockManager.addBlock">Adaugă bloc</message>	

--- a/locale/ru_RU/locale.xml
+++ b/locale/ru_RU/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the ru_RU (Russian) locale.
+  * Localization strings for the ru_RU (Русский) locale.
   *
   -->
  
-<locale name="ru_RU" full_name="Russian">
+<locale name="ru_RU" full_name="Русский">
 	<message key="plugins.generic.customBlockManager.displayName">Модуль собственных блоков</message>
 	<message key="plugins.generic.customBlockManager.blockName">Имя блока</message>	
 	<message key="plugins.generic.customBlockManager.addBlock">Добавить блок</message>	

--- a/locale/sr_SR/locale.xml
+++ b/locale/sr_SR/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the sr_SR (Serbian) locale.
+  * Localization strings for the sr_SR (Cрпски) locale.
   *
   -->
  
-<locale name="sr_SR" full_name="Serbian">
+<locale name="sr_SR" full_name="Cрпски">
 	<message key="plugins.generic.customBlockManager.displayName">Menadžer prilagođenih blokova</message>
 	<message key="plugins.generic.customBlockManager.blockName">Ime bloka</message>	
 	<message key="plugins.generic.customBlockManager.addBlock">Dodaj blok</message>	

--- a/locale/tr_TR/locale.xml
+++ b/locale/tr_TR/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the tr_TR (Turkish) locale.
+  * Localization strings for the tr_TR (Türkçe) locale.
   *
   -->
  
-<locale name="tr_TR" full_name="Türkiye Türkçesi">
+<locale name="tr_TR" full_name="Türkçe">
 	<message key="plugins.generic.customBlockManager.displayName">Özelleştirilmiş Blok Yöneticisi</message>
 	<message key="plugins.generic.customBlockManager.description">This Plugin lets you manage custom sidebar blocks.  You can edit the blocks in the settings of each plugin that you create here.</message>
 	<message key="plugins.generic.customBlockManager.blockName">Blok Adı</message>	

--- a/locale/uk_UA/locale.xml
+++ b/locale/uk_UA/locale.xml
@@ -8,13 +8,13 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the uk_UA (Ukrainian) locale.
+  * Localization strings for the uk_UA (Українська) locale.
   *
   * Translated by Denys Solovianenko, 2011
   * V. I. Vernadsky National Library of Ukraine
   -->
  
-<locale name="uk_UA" full_name="Ukrainian">
+<locale name="uk_UA" full_name="Українська">
        <message key="plugins.generic.customBlockManager.displayName">Менеджер власних блоків</message>
        <message key="plugins.generic.customBlockManager.description">Цей модуль дозволяє керувати власними блоками на панелі.  Ви можете редагувати зміст блоків, створених тут, засобами налаштувань.</message>
        <message key="plugins.generic.customBlockManager.blockName">Назва блоку</message>       

--- a/locale/zh_CN/locale.xml
+++ b/locale/zh_CN/locale.xml
@@ -8,11 +8,11 @@
   * Copyright (c) 2003-2015 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings for the zh_CN (China) locale.
+  * Localization strings for the zh_CN (简体中文) locale.
   *
   -->
  
-<locale name="zh_CN" full_name="China">
+<locale name="zh_CN" full_name="简体中文">
 	<message key="plugins.generic.customBlockManager.displayName">自定义区块管理(Custom Block Manager)</message>
 	<message key="plugins.generic.customBlockManager.description">本插件允许在边栏增加区块，和对边栏区块的重新排序。(This plugin lets you create addition sidebar blocks.  Once they are created, you can edit their content and rearrange them within the sidebars.)</message>	
 	<message key="plugins.generic.customBlockManager.blockName">区块名称(Block Name)</message>	


### PR DESCRIPTION
Following the recent standardization of locale names in the PKP applications, this tackles the customBlockManager plugin.