### PR TITLE
Use default locale fallback

### DIFF
--- a/CustomBlockPlugin.inc.php
+++ b/CustomBlockPlugin.inc.php
@@ -102,7 +102,7 @@ class CustomBlockPlugin extends BlockPlugin {
 		$contextId = $context ? $context->getId() : 0;
 
 		// Get the block contents.
-		$customBlockContent = $this->getSetting($context->getId(), 'blockContent');
+		$customBlockContent = $this->getSetting($contextId, 'blockContent');
 		$currentLocale = AppLocale::getLocale();
 		$contextPrimaryLocale = $context->getPrimaryLocale();
 

--- a/CustomBlockPlugin.inc.php
+++ b/CustomBlockPlugin.inc.php
@@ -98,9 +98,8 @@ class CustomBlockPlugin extends BlockPlugin {
 	 * @copydoc BlockPlugin::getContents()
 	 */
 	function getContents(&$templateMgr, $request = null) {
-		// Ensure that we're dealing with a request with context
 		$context = $request->getContext();
-		if (!$context) return '';
+		$contextId = $context ? $context->getId() : 0;
 
 		// Get the block contents.
 		$customBlockContent = $this->getSetting($context->getId(), 'blockContent');

--- a/CustomBlockPlugin.inc.php
+++ b/CustomBlockPlugin.inc.php
@@ -98,15 +98,21 @@ class CustomBlockPlugin extends BlockPlugin {
 	 * @copydoc BlockPlugin::getContents()
 	 */
 	function getContents(&$templateMgr, $request = null) {
+		// Ensure that we're dealing with a request with context
 		$context = $request->getContext();
-		$contextId = $context ? $context->getId() : 0;
+		if (!$context) return '';
 
 		// Get the block contents.
-		$customBlockContent = $this->getSetting($contextId, 'blockContent');
+		$customBlockContent = $this->getSetting($context->getId(), 'blockContent');
 		$currentLocale = AppLocale::getLocale();
+		$contextPrimaryLocale = $context->getPrimaryLocale();
+
 		$divCustomBlockId = 'customblock-'.preg_replace('/\W+/', '-', $this->getName());
 		$templateMgr->assign('customBlockId', $divCustomBlockId);
-		$templateMgr->assign('customBlockContent', $customBlockContent[$currentLocale]);
+
+		$content = $customBlockContent[$currentLocale] ? $customBlockContent[$currentLocale] : $customBlockContent[$contextPrimaryLocale];
+
+		$templateMgr->assign('customBlockContent', $content);
 		return parent::getContents($templateMgr, $request);
 
 	}


### PR DESCRIPTION
Hi @asmecher 

I noticed that in multilingual journals, if you add a custom block but do not add all translations to correspond the selected UI languages, the plugin will just show an empty place holder for the block.

The pr here will first search for the selected locale version of the block, but will then fallback to context primary locale.

This is handy with blocks where you only have things like Facebook buttons etc. and will want to show the same version for each locale.
