### PR TITLE
Module breaks main front page

### DIFF
--- a/CustomBlockPlugin.inc.php
+++ b/CustomBlockPlugin.inc.php
@@ -104,7 +104,7 @@ class CustomBlockPlugin extends BlockPlugin {
 		// Get the block contents.
 		$customBlockContent = $this->getSetting($contextId, 'blockContent');
 		$currentLocale = AppLocale::getLocale();
-		$contextPrimaryLocale = $context->getPrimaryLocale();
+		$contextPrimaryLocale = $context ? $context->getPrimaryLocale() : null;
 
 		$divCustomBlockId = 'customblock-'.preg_replace('/\W+/', '-', $this->getName());
 		$templateMgr->assign('customBlockId', $divCustomBlockId);


### PR DESCRIPTION
$context might be null in the main front page (outside all journals). In such case, $context->getPrimaryLocale() would throw a FATAL ERROR (PHP message: PHP Fatal error:  Call to a member function getPrimaryLocale() on null), which stops the whole front page from being processed (not sidebar, not footer). However, setting the primary locale in null seems to work that out, making CustomBlock block plugin usable outside the context of any journal.