### PR TITLE
Harmonize de_DE locale with the ojs locale

### DIFF
--- a/locale/de_DE/locale.xml
+++ b/locale/de_DE/locale.xml
@@ -14,7 +14,7 @@
 <locale name="de_DE" full_name="Deutsch (Deutschland)">
 	<message key="plugins.generic.customBlockManager.displayName">Verwaltung benutzerdefinierter Blöcke</message>
 	<message key="plugins.generic.customBlockManager.manage">Benutzerdefinierte Blöcke verwalten</message>
-	<message key="plugins.generic.customBlockManager.description">Dieses Plug-In erlaubt Ihnen, benutzerdefinierte Blöcke in der Sidebar zu verwalten (anzulegen, zu bearbeiten und zu löschen).</message>
+	<message key="plugins.generic.customBlockManager.description">Dieses Plugin erlaubt Ihnen, benutzerdefinierte Blöcke in der Sidebar zu verwalten (anzulegen, zu bearbeiten und zu löschen).</message>
 	<message key="plugins.generic.customBlockManager.customBlocks">Benutzerdefinierte Blöcke</message>	
 	<message key="plugins.generic.customBlockManager.blockName">Name des Blocks</message>
 	<message key="plugins.generic.customBlockManager.addBlock">Block hinzufügen</message>	


### PR DESCRIPTION
The [main locale](https://github.com/pkp/ojs/blob/master/locale/de_DE/locale.xml) of ojs translates `plugin` as `Plugin` not as `Plug-In`.