### PR TITLE
pkp/pkp-lib#5523, pkp/customBlockManager#17: refactor block names and settings, migrate block sidebar contexts

### DIFF
--- a/CustomBlockManagerPlugin.inc.php
+++ b/CustomBlockManagerPlugin.inc.php
@@ -14,6 +14,12 @@
  *
  */
 
+// No constant name in core 3.2 (!?!), per https://github.com/pkp/pkp-lib/commit/a76bac72ed068a1d1866398d20cdf28c4977249f#diff-70caff5ef9a513397af1833a3e2a3c7c
+import('lib.pkp.classes.plugins.BlockPlugin');
+if (!defined('BLOCK_CONTEXT_SIDEBAR')) {
+	define('BLOCK_CONTEXT_SIDEBAR', 1);
+}
+
 import('lib.pkp.classes.plugins.GenericPlugin');
 
 class CustomBlockManagerPlugin extends GenericPlugin {
@@ -62,7 +68,7 @@ class CustomBlockManagerPlugin extends GenericPlugin {
 					foreach ($blocks as $block) {
 						PluginRegistry::register(
 							'blocks',
-							new CustomBlockPlugin($block, $this),
+							new CustomBlockPlugin($block, $this, $contextId),
 							$this->getPluginPath()
 						);
 					}
@@ -145,5 +151,77 @@ class CustomBlockManagerPlugin extends GenericPlugin {
 	 */
 	function isSitePlugin() {
 		return !Application::getRequest()->getContext();
+	}
+
+	/**
+	 * Create a unique name for a child plugin
+	 *
+	 * @return string
+	 */
+	function createUniqueName() {
+		return str_replace('.', 'x', uniqid($this->getUniqueNamePrefix(), true));
+	}
+
+	/**
+	 * Get the name prefix for a child plugin
+	 *
+	 * @return string
+	 */
+	function getUniqueNamePrefix() {
+		return $this->getName().'__';
+	}
+
+	/**
+	 * We will need to modify data in certain upgrades.
+	 *
+	 * @param $hookName string
+	 * @param $args array
+	 * @return boolean
+	 */
+	function installFilters($hookName, $args) {
+		// There is no opportunity to hook the upgrade event before the new version is written to the versions table.
+		// The only function automatically called in installPluginVersion::execute() is installFilters(), so we hijack this.
+		// So, we need to look at the immediately preceeding version, and (re)apply fixes based on guesswork.
+		$versionDao = DAORegistry::getDAO('VersionDAO');
+		$contextDao = Application::getContextDAO();
+		$historicVersions = $versionDao->getVersionHistory('plugins.generic', 'customBlockManager');
+		if (count($historicVersions) > 1 && $historicVersions[1]->compare('1.3.0') < 0) {
+			// The last installed version is prior to 1.3.0
+			// We need up update the plugin_settings names and move any orphaned sidebar contexts
+			$contexts = $contextDao->getAll();
+			while ($context = $contexts->next()) {
+				// Load the custom blocks we have created
+				$blocks = $this->getSetting($context->getId(), 'blocks');
+				if (!is_array($blocks)) $blocks = array();
+				$pluginSettingsDao = DAORegistry::getDAO('PluginSettingsDAO');
+				$newBlocks = array();
+				foreach ($blocks as $blockName) {
+					// Current block uses old naming
+					if (strpos($blockName, $this->getUniqueNamePrefix()) !== 0) {
+						$newBlockName = $this->createUniqueName();
+						// Update plugin_settings
+						$settings = $pluginSettingsDao->getPluginSettings($context->getId(), $blockName);
+						foreach ($settings as $setting_name => $setting_value) {
+							switch ($setting_name) {
+								case 'context':
+									$setting_value = BLOCK_CONTEXT_SIDEBAR;
+								case 'blockContent':
+								case 'enabled':
+								case 'seq':
+									$pluginSettingsDao->deleteSetting($context->getId(), $blockName, $setting_name);
+									$pluginSettingsDao->updateSetting($context->getId(), $newBlockName, $setting_name, $setting_value);
+									break;
+								default:
+									error_log('found an unrecognized setting "'.$setting_name.'", in custom block "'.$blockName.'"');
+							}
+						}
+						$pluginSettingsDao->updateSetting($context->getId(), $newBlockName, 'blockDisplayName', $blockName);
+					}
+					$newBlocks[] = $newBlockName;
+				}
+				$this->updateSetting($context->getId(), 'blocks', $newBlocks);
+			}
+		}
+		return parent::installFilters($hookName, $args);
 	}
 }

--- a/CustomBlockPlugin.inc.php
+++ b/CustomBlockPlugin.inc.php
@@ -19,6 +19,8 @@ import('lib.pkp.classes.plugins.BlockPlugin');
 class CustomBlockPlugin extends BlockPlugin {
 	/** @var string Name of this block plugin */
 	var $_blockName;
+	/** @var int Context ID */
+	var $_contextId;
 
 	/** @var CustomBlockManagerPlugin Parent plugin */
 	var $_parentPlugin;
@@ -27,10 +29,12 @@ class CustomBlockPlugin extends BlockPlugin {
 	 * Constructor
 	 * @param $blockName string Name of this block plugin.
 	 * @param $parentPlugin CustomBlockManagerPlugin Custom block plugin management plugin.
+	 * @param $contextId int The context in which this plugin lives
 	 */
-	function __construct($blockName, $parentPlugin) {
+	function __construct($blockName, $parentPlugin, $contextId) {
 		$this->_blockName = $blockName;
 		$this->_parentPlugin = $parentPlugin;
+		$this->_contextId = $contextId;
 		parent::__construct();
 	}
 
@@ -84,7 +88,7 @@ class CustomBlockPlugin extends BlockPlugin {
 	 * @copydoc Plugin::getDisplayName()
 	 */
 	function getDisplayName() {
-		return $this->_blockName . ' ' . __('plugins.generic.customBlock.nameSuffix');
+		return $this->getSetting($this->_contextId, 'blockDisplayName') . ' ' . __('plugins.generic.customBlock.nameSuffix');
 	}
 
 	/**

--- a/controllers/grid/CustomBlockGridHandler.inc.php
+++ b/controllers/grid/CustomBlockGridHandler.inc.php
@@ -68,8 +68,9 @@ class CustomBlockGridHandler extends GridHandler {
 		$blocks = $customBlockManagerPlugin->getSetting($contextId, 'blocks');
 		$gridData = array();
 		if (is_array($blocks)) foreach ($blocks as $block) {
+			$plugin = new CustomBlockPlugin($block, $customBlockManagerPlugin, $contextId);
 			$gridData[$block] = array(
-				'title' => $block
+				'title' => $plugin->getSetting($contextId, 'blockDisplayName')
 			);
 		}
 		$this->setGridDataElements($gridData);
@@ -134,7 +135,7 @@ class CustomBlockGridHandler extends GridHandler {
 	function editCustomBlock($args, $request) {
 		$blockName = $request->getUserVar('blockName');
 		$context = $request->getContext();
-		$contextId = $context ? $context->getId() : 0;
+		$contextId = $context ? $context->getId() : CONTEXT_ID_NONE;
 		$this->setupTemplate($request);
 
 		$customBlockPlugin = null;
@@ -142,7 +143,7 @@ class CustomBlockGridHandler extends GridHandler {
 		if ($blockName) {
 			// Create the custom block plugin
 			import('plugins.generic.customBlockManager.CustomBlockPlugin');
-			$customBlockPlugin = new CustomBlockPlugin($blockName, CUSTOMBLOCKMANAGER_PLUGIN_NAME);
+			$customBlockPlugin = new CustomBlockPlugin($blockName, $this->plugin, $contextId);
 		}
 
 		// Create and present the edit form
@@ -171,7 +172,7 @@ class CustomBlockGridHandler extends GridHandler {
 		if ($pluginName) {
 			// Create the custom block plugin
 			import('plugins.generic.customBlockManager.CustomBlockPlugin');
-			$customBlockPlugin = new CustomBlockPlugin($pluginName, CUSTOMBLOCKMANAGER_PLUGIN_NAME);
+			$customBlockPlugin = new CustomBlockPlugin($pluginName, $this->plugin, $contextId);
 		}
 
 		// Create and populate the form

--- a/controllers/grid/form/CustomBlockForm.inc.php
+++ b/controllers/grid/form/CustomBlockForm.inc.php
@@ -38,8 +38,7 @@ class CustomBlockForm extends Form {
 		// Add form checks
 		$this->addCheck(new FormValidatorPost($this));
 		$this->addCheck(new FormValidatorCSRF($this));
-		$this->addCheck(new FormValidator($this, 'blockName', 'required', 'plugins.generic.customBlock.nameRequired'));
-		$this->addCheck(new FormValidatorRegExp($this, 'blockName', 'required', 'plugins.generic.customBlock.nameRegEx', '/^[a-zA-Z0-9_-]+$/'));
+		$this->addCheck(new FormValidator($this, 'blockDisplayName', 'required', 'plugins.generic.customBlock.nameRequired'));
 	}
 
 	/**
@@ -49,23 +48,23 @@ class CustomBlockForm extends Form {
 		$contextId = $this->contextId;
 		$plugin = $this->plugin;
 
-		$templateMgr = TemplateManager::getManager();
-
 		$blockName = null;
 		$blockContent = null;
 		if ($plugin) {
 			$blockName = $plugin->getName();
+			$blockDisplayName = $plugin->getSetting($contextId, 'blockDisplayName');
 			$blockContent = $plugin->getSetting($contextId, 'blockContent');
 		}
 		$this->setData('blockContent', $blockContent);
 		$this->setData('blockName', $blockName);
+		$this->setData('blockDisplayName', $blockDisplayName);
 	}
 
 	/**
 	 * Assign form data to user-submitted data.
 	 */
 	function readInputData() {
-		$this->readUserVars(array('blockName', 'blockContent'));
+		$this->readUserVars(array('blockName', 'blockDisplayName', 'blockContent'));
 	}
 
 	/**
@@ -74,11 +73,13 @@ class CustomBlockForm extends Form {
 	function execute() {
 		$plugin = $this->plugin;
 		$contextId = $this->contextId;
+		$blockName = $this->getData('blockName');
 		if (!$plugin) {
 			// Create a new custom block plugin
 			import('plugins.generic.customBlockManager.CustomBlockPlugin');
 			$customBlockManagerPlugin = PluginRegistry::getPlugin('generic', CUSTOMBLOCKMANAGER_PLUGIN_NAME);
-			$plugin = new CustomBlockPlugin($this->getData('blockName'), $customBlockManagerPlugin);
+			$blockName = $customBlockManagerPlugin->createUniqueName();
+			$plugin = new CustomBlockPlugin($blockName, $customBlockManagerPlugin, $contextId);
 			// Default the block to being enabled
 			$plugin->setEnabled(true);
 
@@ -90,12 +91,13 @@ class CustomBlockForm extends Form {
 			$blocks = $customBlockManagerPlugin->getSetting($contextId, 'blocks');
 			if (!isset($blocks)) $blocks = array();
 
-			array_push($blocks, $this->getData('blockName'));
+			$blocks[] = $blockName;
 			$customBlockManagerPlugin->updateSetting($contextId, 'blocks', $blocks);
 		}
 
 		// update custom block plugin content
 		$plugin->updateSetting($contextId, 'blockContent', $this->getData('blockContent'));
+		$plugin->updateSetting($contextId, 'blockDisplayName', $this->getData('blockDisplayName'));
 	}
 }
 

--- a/locale/ar_IQ/locale.xml
+++ b/locale/ar_IQ/locale.xml
@@ -24,5 +24,4 @@
 	<message key="plugins.generic.customBlock.nameSuffix">(إضافة الكتلة المخصصة)</message>
 	<message key="plugins.generic.customBlock.description">هذه كتلة مولدة من قبل المستخدم.</message>
 	<message key="plugins.generic.customBlock.nameRequired">اسم الكتلة المخصصة مطلوب حتماً.</message>
-	<message key="plugins.generic.customBlock.nameRegEx">اسم الكتلة المخصصة يجب أن يقتصر على الحروف والأرقام وعلامة الطرح والخط التحتاني.</message>
 </locale>

--- a/locale/cs_CZ/locale.xml
+++ b/locale/cs_CZ/locale.xml
@@ -24,5 +24,4 @@
 	<message key="plugins.generic.customBlock.nameSuffix">(Plugin uživatelských panelů)</message>
 	<message key="plugins.generic.customBlockManager.description">Tento plugin vám umožňuje spravovat (přidávat, upravovat a odstraňovat) vlastní bloky v postranních panelech.</message>
 	<message key="plugins.generic.customBlock.nameRequired">Je třeba zadat jméno uživatelského bloku.</message>
-	<message key="plugins.generic.customBlock.nameRegEx">Název uživatelského bloku musí obsahovat pouze písmena, čísla a pomlčky/podtržítka.</message>
 </locale>

--- a/locale/da_DK/locale.xml
+++ b/locale/da_DK/locale.xml
@@ -24,5 +24,4 @@
 	<message key="plugins.generic.customBlock.nameSuffix">(Brugerdefineret blok)</message>
 	<message key="plugins.generic.customBlock.description">Dette er et brugerdefineret element.</message>
 	<message key="plugins.generic.customBlock.nameRequired">Et brugerdefineret blok-navn er påkrævet.</message>
-	<message key="plugins.generic.customBlock.nameRegEx">Det brugerdefinerede blok-navn må indeholde bogstaver, numre og bindestreg/understregning.</message>
 </locale>

--- a/locale/de_DE/locale.xml
+++ b/locale/de_DE/locale.xml
@@ -24,5 +24,4 @@
 	<message key="plugins.generic.customBlock.nameSuffix">(Benutzerdefinierter Block)</message>
 	<message key="plugins.generic.customBlock.description">Dies ist ein selbst angelegter Block.</message>
 	<message key="plugins.generic.customBlock.nameRequired">Der Name des benutzerdefinierten Blocks wird benötigt.</message>
-	<message key="plugins.generic.customBlock.nameRegEx">Der Name des benutzerdefinierten Blocks darf nur Buchstaben, Ziffern und Bindestriche/Unterstriche enthalten.</message>
 </locale>

--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -24,5 +24,4 @@
 	<message key="plugins.generic.customBlock.nameSuffix">(Custom Block)</message>
 	<message key="plugins.generic.customBlock.description">This is a user-generated block.</message>
 	<message key="plugins.generic.customBlock.nameRequired">The custom block name is required.</message>
-	<message key="plugins.generic.customBlock.nameRegEx">The custom block name must contain only letters, numbers, and hyphens/underscores.</message>
 </locale>

--- a/locale/es_ES/locale.xml
+++ b/locale/es_ES/locale.xml
@@ -24,5 +24,4 @@
 	<message key="plugins.generic.customBlock.nameSuffix">(Bloque Personalizado)</message>
 	<message key="plugins.generic.customBlock.description">Este es un Bloque generado por el usuario.</message>
 	<message key="plugins.generic.customBlock.nameRequired">Se requiere el nombre del bloque personalizado.</message>
-	<message key="plugins.generic.customBlock.nameRegEx">El nombre del bloque personalizado sólo debe contener letras, números y guiones/guiones bajos.</message>
 </locale>

--- a/locale/fi_FI/locale.xml
+++ b/locale/fi_FI/locale.xml
@@ -24,5 +24,4 @@
 	<message key="plugins.generic.customBlock.nameSuffix">(Mukautettu lohko)</message>
 	<message key="plugins.generic.customBlock.description">Tämä on käyttäjän luoma lohko.</message>
 	<message key="plugins.generic.customBlock.nameRequired">Mukautetun lohkon nimi vaaditaan.</message>
-	<message key="plugins.generic.customBlock.nameRegEx">Mukautetun lohkon nimi voi sisältää vain kirjaimia, numeroita ja yhdysmerkkejä/alaviivoja.</message>
 </locale>

--- a/locale/fr_CA/locale.xml
+++ b/locale/fr_CA/locale.xml
@@ -25,5 +25,4 @@
 	<message key="plugins.generic.customBlockManager.customBlocks">Blocs personnalisés</message>
 	<message key="plugins.generic.customBlockManager.noneCreated">Aucun bloc personnalisé n'a été créé.</message>
 	<message key="plugins.generic.customBlock.nameRequired">Le nom du bloc personnalisé est requis.</message>
-	<message key="plugins.generic.customBlock.nameRegEx">Le nom du bloc personnalisé ne doit contenir que des lettres, des chiffres, des tirets et/ou des traits de soulignement.</message>
 </locale>

--- a/locale/it_IT/locale.xml
+++ b/locale/it_IT/locale.xml
@@ -24,5 +24,4 @@
 	<message key="plugins.generic.customBlock.nameSuffix">(blocco personalizzato)</message>
 	<message key="plugins.generic.customBlock.description">Questo è un blocco generato dall'utente.</message>
 	<message key="plugins.generic.customBlock.nameRequired">Il nome del blocco personalizzato è necessario</message>
-	<message key="plugins.generic.customBlock.nameRegEx">Il nome del blocco personalizzato può contenere solo lettere, numeri e trattini alti o bassi.</message>
 </locale>

--- a/locale/nl_NL/locale.xml
+++ b/locale/nl_NL/locale.xml
@@ -25,5 +25,4 @@
 	<message key="plugins.generic.customBlock.nameSuffix">(Eigen blokken plugin)</message>
 	<message key="plugins.generic.customBlock.description">Dit is een zelfgemaakt blok.</message>
 	<message key="plugins.generic.customBlock.nameRequired">Een naam is verplicht voor het eigen blok.</message>
-	<message key="plugins.generic.customBlock.nameRegEx">De naam van het eigen blok mag uitsluitend letters, cijfers en koppeltekens of liggende streepjes bevatten.</message>
 </locale>

--- a/locale/pt_BR/locale.xml
+++ b/locale/pt_BR/locale.xml
@@ -25,5 +25,4 @@
 	<message key="plugins.generic.customBlockManager.customBlocks">Blocos Personalizados</message>
 	<message key="plugins.generic.customBlockManager.noneCreated">Não há blocos personalizados criados.</message>
 	<message key="plugins.generic.customBlock.nameRequired">O nome do bloco personalizado é necessário.</message>
-	<message key="plugins.generic.customBlock.nameRegEx">O nome do bloco personalizado deve conter apenas letras, números e hífens / sublinhados.</message>
 </locale>

--- a/locale/pt_PT/locale.xml
+++ b/locale/pt_PT/locale.xml
@@ -25,5 +25,4 @@
 	<message key="plugins.generic.customBlockManager.customBlocks">Blocos Personalizados</message>
 	<message key="plugins.generic.customBlockManager.noneCreated">Nenhum bloco personalizado criado.</message>
 	<message key="plugins.generic.customBlock.nameRequired">O nome do bloco personalizado é obrigatório.</message>
-	<message key="plugins.generic.customBlock.nameRegEx">O nome do bloco personalizado só pode conter letras, números e hífenes ou sublinhados.</message>
 </locale>

--- a/locale/ru_RU/locale.xml
+++ b/locale/ru_RU/locale.xml
@@ -24,5 +24,4 @@
 	<message key="plugins.generic.customBlock.nameSuffix">(пользовательский блок)</message>
 	<message key="plugins.generic.customBlock.description">Это пользовательский блок.</message>
 	<message key="plugins.generic.customBlock.nameRequired">Имя пользовательского блока обязательно.</message>
-	<message key="plugins.generic.customBlock.nameRegEx">Имя пользовательского блока должно содержать только буквы, цифры, дефисы и подчеркивания.</message>
 </locale>

--- a/locale/sl_SI/locale.xml
+++ b/locale/sl_SI/locale.xml
@@ -24,5 +24,4 @@
 	<message key="plugins.generic.customBlock.nameSuffix">(Uporabniški blok)</message>
 	<message key="plugins.generic.customBlock.description">To blok, ki ga je ustvaril uporabnik.</message>
 	<message key="plugins.generic.customBlock.nameRequired">Ime bloka je obvezno.</message>
-	<message key="plugins.generic.customBlock.nameRegEx">Ime bloka lahko vsebuje le črke, številke in pomišljaj/podčrtaj.</message>
 </locale>

--- a/locale/sr_RS@latin/locale.xml
+++ b/locale/sr_RS@latin/locale.xml
@@ -23,5 +23,4 @@
 	<message key="plugins.generic.customBlockManager.customBlocks">Prilagođeni blokovi</message>
 	<message key="plugins.generic.customBlockManager.noneCreated">Nema prilagođenih blokova.</message>
 	<message key="plugins.generic.customBlock.nameRequired">Ime bloka je oavezno.</message>
-	<message key="plugins.generic.customBlock.nameRegEx">Ime bloka može sadržati samo slova, brojeve, crte i podvlake.</message>
 </locale>

--- a/locale/sv_SE/locale.xml
+++ b/locale/sv_SE/locale.xml
@@ -24,5 +24,4 @@
 	<message key="plugins.generic.customBlock.nameSuffix">(Anpassat block)</message>
 	<message key="plugins.generic.customBlock.description">Det här är ett användargenererat block.</message>
 	<message key="plugins.generic.customBlock.nameRequired">Ett namn på det anpassade blocket krävs.</message>
-	<message key="plugins.generic.customBlock.nameRegEx">Det anpassade blockets namn får bara innehålla bokstäver, siffror och bindestreck/understreck.</message>
 </locale>

--- a/locale/tr_TR/locale.xml
+++ b/locale/tr_TR/locale.xml
@@ -25,5 +25,4 @@
 	<message key="plugins.generic.customBlockManager.customBlocks">Özel Bloklar</message>
 	<message key="plugins.generic.customBlockManager.noneCreated">Özel blok oluşturulmadı.</message>
 	<message key="plugins.generic.customBlock.nameRequired">Özel blok adı gerekli.</message>
-	<message key="plugins.generic.customBlock.nameRegEx">Özel blok adı sadece harf, sayı ve kısa çizgi / alt çizgi içermelidir.</message>
 </locale>

--- a/locale/uk_UA/locale.xml
+++ b/locale/uk_UA/locale.xml
@@ -24,5 +24,4 @@
 	<message key="plugins.generic.customBlock.nameSuffix">(власний блок)</message>
 	<message key="plugins.generic.customBlock.description">Це створений користувачем блок.</message>
 	<message key="plugins.generic.customBlock.nameRequired">Назва власного блоку обов'язкова.</message>
-	<message key="plugins.generic.customBlock.nameRegEx">Назва власного блоку повинна містити лише літери, цифри, дефіс та підкреслювання.</message>
 </locale>

--- a/templates/editCustomBlockForm.tpl
+++ b/templates/editCustomBlockForm.tpl
@@ -19,7 +19,8 @@
 	{csrf}
 	{fbvFormArea id="customBlocksFormArea" class="border"}
 		{fbvFormSection}
-			{fbvElement type="text" label="plugins.generic.customBlockManager.blockName" id="blockName" value=$blockName maxlength="40" inline=true size=$fbvStyles.size.MEDIUM}
+			{fbvElement type="hidden" id="blockName" value=$blockName}
+			{fbvElement type="text" label="plugins.generic.customBlockManager.blockName" id="blockDisplayName" value=$blockDisplayName maxlength="40" inline=true size=$fbvStyles.size.MEDIUM}
 		{/fbvFormSection}
 		{fbvFormSection label="plugins.generic.customBlock.content" for="blockContent"}
 			{fbvElement type="textarea" multilingual=true name="blockContent" id="blockContent" value=$blockContent rich=true height=$fbvStyles.height.TALL}

--- a/version.xml
+++ b/version.xml
@@ -13,8 +13,8 @@
 <version>
 	<application>customBlockManager</application>
 	<type>plugins.generic</type>
-	<release>1.2.0.0</release>
-	<date>2014-09-19</date>
+	<release>1.3.0.0</release>
+	<date>2020-03-02</date>
 	<lazy-load>1</lazy-load>
 	<class>CustomBlockManagerPlugin</class>
 </version>


### PR DESCRIPTION
On upgrade to version 1.3.0-0 or later, review existing custom blocks and migrate each to a uniquely generated block plugin name.

Reset all unrecognized sidebar contexts to the `BLOCK_CONTEXT_SIDEBAR`.

Resolves pkp/pkp-lib#5523 and pkp/customBlockManager#17 .
