### PR TITLE
pkp/pkp-lib#6209 Multiple use of id="setup-button" in website settings

### DIFF
--- a/cypress/tests/functional/CustomBlocks.spec.js
+++ b/cypress/tests/functional/CustomBlocks.spec.js
@@ -37,7 +37,7 @@ describe('Custom Block Manager plugin tests', function() {
 		// FIXME: The settings area has to be reloaded before the new block will appear.a
 		// This click should be unnecessary.
 		cy.get('.app__nav a').contains('Website').click();
-		cy.get('#appearance > .pkpTabs > .pkpTabs__buttons > #setup-button').click();
+		cy.get('#appearance > .pkpTabs > .pkpTabs__buttons > #appearance-setup-button').click();
 		cy.get('#setup span:contains("test-custom-block"):first').click();
 		cy.get('#setup button:contains("Save")').click();
 		cy.waitJQuery();


### PR DESCRIPTION
This aims to solve the issue pkp/pkp-lib#6209 . It's update the cypress tests to make sure the tests pass for the changes to `ojs` repo pull request made at https://github.com/pkp/ojs/pull/3371 