### PR TITLE
pkp/pkp-lib#6209 Multiple use of id="setup-button" in website settings fixing

### DIFF
--- a/cypress/tests/functional/CustomBlocks.spec.js
+++ b/cypress/tests/functional/CustomBlocks.spec.js
@@ -37,7 +37,7 @@ describe('Custom Block Manager plugin tests', function() {
 		// FIXME: The settings area has to be reloaded before the new block will appear.a
 		// This click should be unnecessary.
 		cy.get('.app__nav a').contains('Website').click();
-		cy.get('#appearance > .pkpTabs > .pkpTabs__buttons > #setup-button').click();
+		cy.get('#appearance > .pkpTabs > .pkpTabs__buttons > #appearance-setup-button').click();
 		cy.get('#setup span:contains("test-custom-block"):first').click();
 		cy.get('#setup button:contains("Save")').click();
 		cy.waitJQuery();


### PR DESCRIPTION
fix to issue https://github.com/pkp/pkp-lib/issues/6209 which eliminate the multiple use of `duplicate id="setup-button"` in website settings for `main` branch .